### PR TITLE
Prevent module system errors from commonjs in the default config file

### DIFF
--- a/src/util/defaults.ts
+++ b/src/util/defaults.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 
 export default {
-  configFile: '.fauna-migrate.js',
+  configFile: '.fauna-migrate.cjs',
   directories: {
     root: 'fauna',
     // Below resources will be placed in the root folder


### PR DESCRIPTION
If `fauna-schema-migrate init` is run in a project which has already indicated that it is using esmodules (by setting `"type": "module"` in the nearest `package.json` file), the resulting default `.fauna-migrate.js` file will be treated as an esmodule by the node runtime.

Since the generated file uses commonjs modules, this causes an immediate runtime error.

By changing the file extension to `.cjs`, we're telling the node runtime to expect commonjs modules in this file regardless of whether the parent project is using esmodules.

An alternative approach would be to match the parent project's module system in the generated code.